### PR TITLE
fix(reporter): don't print all dots in one line

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -459,7 +459,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -501,7 +500,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1115,7 +1113,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -1411,37 +1408,17 @@
       "license": "MIT"
     },
     "node_modules/@simple-libs/stream-utils": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.1.0.tgz",
-      "integrity": "sha512-6rsHTjodIn/t90lv5snQjRPVtOosM7Vp0AKdrObymq45ojlgVwnpAqdc+0OBBrpEiy31zZ6/TKeIVqV1HwvnuQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
+      "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@types/node": "^22.0.0"
-      },
       "engines": {
         "node": ">=18"
       },
       "funding": {
         "url": "https://ko-fi.com/dangreen"
       }
-    },
-    "node_modules/@simple-libs/stream-utils/node_modules/@types/node": {
-      "version": "22.19.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
-      "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@simple-libs/stream-utils/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
@@ -1480,7 +1457,6 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1526,7 +1502,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2126,7 +2101,6 @@
       "integrity": "sha512-20pyHgnO40rvfI0NGF/xiEoFMkXDtkF8FwHvk5BokoFoCuTQRI8vrNCNFWUOfuolKJMm1tPCHc8GgYEtr1XRNA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "meow": "^13.0.0"
       },
@@ -2143,7 +2117,6 @@
       "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2233,7 +2206,6 @@
       "integrity": "sha512-20pyHgnO40rvfI0NGF/xiEoFMkXDtkF8FwHvk5BokoFoCuTQRI8vrNCNFWUOfuolKJMm1tPCHc8GgYEtr1XRNA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "meow": "^13.0.0"
       },
@@ -2256,7 +2228,6 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -2616,7 +2587,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4775,7 +4745,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4974,7 +4943,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nodeutils/defaults-deep": "1.1.0",
         "@octokit/rest": "22.0.0",

--- a/reporter.js
+++ b/reporter.js
@@ -2,6 +2,8 @@ import chalk from "chalk";
 import { prettyMs } from "./lib/prettyMs.js";
 import * as Diff from "diff";
 
+const MAX_DOTS_PER_LINE = 100;
+
 function serializeForDiff( value ) {
 
 	// Use naive serialization for everything except types with confusable values
@@ -14,11 +16,23 @@ function serializeForDiff( value ) {
 	return `${ value }`;
 }
 
+let currDots = 0;
+function writeDot() {
+	if ( currDots >= MAX_DOTS_PER_LINE ) {
+
+		// Write a newline character occasionally to force a CI output flush.
+		process.stdout.write( "\n" );
+		currDots = 0;
+	}
+	currDots++;
+	process.stdout.write( "." );
+}
+
 export function reportTest( test, { fullBrowser, id } ) {
 	if ( test.status === "passed" ) {
 
-		// Write to console without newlines
-		process.stdout.write( "." );
+		// Write to console
+		writeDot();
 		return;
 	}
 

--- a/reporter.js
+++ b/reporter.js
@@ -128,6 +128,8 @@ export function reportTest( test, { fullBrowser, id } ) {
 }
 
 export function reportError( error ) {
+	currDots = 0;
+
 	const title = `${ error.name || "Error" }: ${ error.message }`;
 	let message = chalk.red( title );
 
@@ -139,6 +141,8 @@ export function reportError( error ) {
 }
 
 export function reportEnd( result, { descriptiveUrl, fullBrowser, id } ) {
+	currDots = 0;
+
 	console.log(
 		`\n\nTests finished in ${ prettyMs( result.runtime ) } ` +
 			`at ${ chalk.yellow( descriptiveUrl ) } ` +


### PR DESCRIPTION
CI systems like GitHub Actions only print a line when a newline character is printed. Add a newline character after each 100 dots to flush output mid-test.

Also, fix the lockfile (without it, CI doesn't pass).

Fixes gh-30